### PR TITLE
Update build workflow to use VS 2026 Build Tools

### DIFF
--- a/.github/workflows/build-winuae-binary.yml
+++ b/.github/workflows/build-winuae-binary.yml
@@ -45,6 +45,7 @@ jobs:
 
     # Running roughly step 12 of README.md
     - name: Build Win32 FullRelease
+      shell: cmd
       working-directory: ${{env.GITHUB_WORKSPACE}}
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
@@ -89,6 +90,7 @@ jobs:
 
     # Running roughly step 12 of README.md
     - name: Build x64 FullRelease
+      shell: cmd
       working-directory: ${{env.GITHUB_WORKSPACE}}
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference

--- a/.github/workflows/build-winuae-binary.yml
+++ b/.github/workflows/build-winuae-binary.yml
@@ -19,10 +19,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v2
-      with:
-        vs-version: '[18.0]'
+    - name: Install Visual Studio Build Tools
+      shell: pwsh
+      run: |
+        Write-Host "Installing VS 2026 Build Tools..."
+        choco install visualstudio2026buildtools `
+          --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --includeRecommended --quiet" `
+          -y --ignore-package-exit-codes=3010
+        Write-Host "VS 2026 Build Tools installation completed" 
 
     # Running roughly step 4 of README.md
     - name: Download WinUAE includes and libs
@@ -35,17 +39,6 @@ jobs:
         file_path: winuaeinclibs.zip
         extract_dir: C:\\dev
 
-    # Running roughly step 6 of README.md
-    - name: Download AROS ROM cpp
-      shell: powershell
-      run: Invoke-WebRequest -Uri "https://download.abime.net/winuae/files/b/aros.rom.cpp.zip" -OutFile "aros.rom.cpp.zip"
-
-    - name: Unpack AROS ROM cpp
-      uses: ihiroky/extract-action@v1
-      with:
-        file_path: aros.rom.cpp.zip
-        extract_dir: .
-
     # Running roughly step 7 of README.md
     - name: Add NASM to PATH
       uses: ilammy/setup-nasm@v1.5.1
@@ -55,7 +48,9 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-      run: msbuild /m /p:Platform=Win32 /p:Configuration=FullRelease ${{env.SOLUTION_FILE_PATH}}
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\Common7\Tools\VsDevCmd.bat"
+        msbuild /m /p:Platform=Win32 /p:Configuration=FullRelease ${{env.SOLUTION_FILE_PATH}}
 
     - uses: actions/upload-artifact@v4
       with:
@@ -68,10 +63,14 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v2
-      with:
-        vs-version: '[18.0]'
+    - name: Install Visual Studio Build Tools
+      shell: pwsh
+      run: |
+        Write-Host "Installing VS 2026 Build Tools..."
+        choco install visualstudio2026buildtools `
+          --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --includeRecommended --quiet" `
+          -y --ignore-package-exit-codes=3010
+        Write-Host "VS 2026 Build Tools installation completed" 
 
     # Running roughly step 4 of README.md
     - name: Download WinUAE includes and libs
@@ -84,17 +83,6 @@ jobs:
         file_path: winuaeinclibs.zip
         extract_dir: C:\\dev
 
-    # Running roughly step 6 of README.md
-    - name: Download AROS ROM cpp
-      shell: powershell
-      run: Invoke-WebRequest -Uri "https://download.abime.net/winuae/files/b/aros.rom.cpp.zip" -OutFile "aros.rom.cpp.zip"
-
-    - name: Unpack AROS ROM cpp
-      uses: ihiroky/extract-action@v1
-      with:
-        file_path: aros.rom.cpp.zip
-        extract_dir: .
-
     # Running roughly step 7 of README.md
     - name: Add NASM to PATH
       uses: ilammy/setup-nasm@v1.5.1
@@ -104,7 +92,9 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-      run: msbuild /m /p:Platform=x64 /p:Configuration=FullRelease ${{env.SOLUTION_FILE_PATH}}
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\Common7\Tools\VsDevCmd.bat"
+        msbuild /m /p:Platform=x64 /p:Configuration=FullRelease ${{env.SOLUTION_FILE_PATH}}
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build-winuae-binary.yml
+++ b/.github/workflows/build-winuae-binary.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v2
+      
     - name: Install Visual Studio Build Tools
       shell: pwsh
       run: |
@@ -64,6 +67,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v2
+      
     - name: Install Visual Studio Build Tools
       shell: pwsh
       run: |

--- a/.github/workflows/build-winuae-binary.yml
+++ b/.github/workflows/build-winuae-binary.yml
@@ -3,12 +3,12 @@ name: Build WinUAE binary
 on:
   workflow_dispatch:
   push:
-    branches: 
+    branches:
       - master
   pull_request:
     branches:
       - master
-      
+
 env:
   SOLUTION_FILE_PATH: od-win32\\winuae_msvc15
 
@@ -21,26 +21,26 @@ jobs:
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v2
-      
+
     - name: Install Visual Studio Build Tools
       shell: pwsh
       run: |
         Write-Host "Installing VS 2026 Build Tools..."
         choco install visualstudio2026buildtools `
-          --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --includeRecommended --quiet" `
+          --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.ATL --add Microsoft.VisualStudio.Component.VC.ATLMFC --includeRecommended --quiet" `
           -y --ignore-package-exit-codes=3010
-        Write-Host "VS 2026 Build Tools installation completed" 
+        Write-Host "VS 2026 Build Tools installation completed"
 
     # Running roughly step 4 of README.md
     - name: Download WinUAE includes and libs
       shell: powershell
       run: Invoke-WebRequest -Uri "https://download.abime.net/winuae/files/b/winuaeinclibs.zip" -OutFile "winuaeinclibs.zip"
 
-    - name: Unpack WinUAE includes and libs to C:\\dev
+    - name: Unpack WinUAE includes and libs to C:\dev
       uses: ihiroky/extract-action@v1
       with:
         file_path: winuaeinclibs.zip
-        extract_dir: C:\\dev
+        extract_dir: C:\dev
 
     # Running roughly step 7 of README.md
     - name: Add NASM to PATH
@@ -59,7 +59,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: WinUAE 32-bit
-        path: D:\\Amiga
+        path: D:\Amiga
 
   Build-WinUAE-64bit-binary:
     runs-on: windows-latest
@@ -69,26 +69,26 @@ jobs:
 
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v2
-      
+
     - name: Install Visual Studio Build Tools
       shell: pwsh
       run: |
         Write-Host "Installing VS 2026 Build Tools..."
         choco install visualstudio2026buildtools `
-          --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --includeRecommended --quiet" `
+          --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.VC.ATL --add Microsoft.VisualStudio.Component.VC.ATLMFC --includeRecommended --quiet" `
           -y --ignore-package-exit-codes=3010
-        Write-Host "VS 2026 Build Tools installation completed" 
+        Write-Host "VS 2026 Build Tools installation completed"
 
     # Running roughly step 4 of README.md
     - name: Download WinUAE includes and libs
       shell: powershell
       run: Invoke-WebRequest -Uri "https://download.abime.net/winuae/files/b/winuaeinclibs.zip" -OutFile "winuaeinclibs.zip"
 
-    - name: Unpack WinUAE includes and libs to C:\\dev
+    - name: Unpack WinUAE includes and libs to C:\dev
       uses: ihiroky/extract-action@v1
       with:
         file_path: winuaeinclibs.zip
-        extract_dir: C:\\dev
+        extract_dir: C:\dev
 
     # Running roughly step 7 of README.md
     - name: Add NASM to PATH
@@ -107,4 +107,4 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: WinUAE 64-bit
-        path: D:\\Amiga
+        path: D:\Amiga


### PR DESCRIPTION
Replaced MSBuild setup with Visual Studio 2026 Build Tools installation. Removed AROS ROM download and unpacking steps.